### PR TITLE
Added default values for configuration, tests & some refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Code Check #
 
 Do you have a problem with duplicated functions in your java project? Here is the solution on how to find all the duplicate functions, specify the location of your repository in the local-config.properties file (just make a copy of config.properties) and run the code! Then you will get a file in "results" with all the places where functions match.
@@ -66,32 +67,19 @@ The results will be shown in the `/results/` folder. By default, the result nami
 ## Configuration file ##
 You can edit some configuration in `config.properties`.
 
-<details>
-  <summary>
-    Default configuration (click to expand)
-  </summary>
-
-###### *config.properties*
-```shell
-LOGGING_LEVEL=INFO
-  # This is related to TEMP_FILE below.
-TEMP_FILE_ENABLED=false
-  # If enabled, this file will be deleted and replaced every run instead of using the results files.
-TEMP_FILE=debugFile.txt
-  # Directory of where the result files are saved. They range from 0 to 99.
-PATH_TO_RESULTS=results
-  # Set this property to a path that should be excluded. It's regex based, so writing [file1, file2] would exclude any file containing file1 and file2.
-EXCLUDED_PATHS=[]
-  # Prefix for the result files.
-RESULT_NAME_PREFIX=result_{nr}
-  # The LLM located in project root.
-LLM_FILE=models/ggml-model-gpt4all-falcon-q4_0.bin
-  # Run with LLM - needs a model defined and will take more computing power and time to run.
-RUN_WITH_LLM=false
-  # Directory path to where the code is to be scanned.
-PATH_TO_CODE=src/test/resources/
-```
-</details>
+### Properties
+| Property           | Default values if not set (if not required) | Type                 | Description                                                  |
+|--------------------|---------------------------------------------|----------------------|--------------------------------------------------------------|
+| LOGGING_LEVEL      | DEBUG                                       | String               | What level to show logs in.                                  |
+| TEMP_FILE_ENABLED  | false                                       | Boolean (true/false) | Whether to use a temporary file.                             |
+| TEMP_FILE          | debugFile.txt                               | String               | Where the temporary file is located.                         |
+| PATH_TO_RESULTS    | results                                     | String               | Results directory.                                           |
+| RESULTS_FILE_LIMIT | 100                                         | Integer              | Since it's creating a new file each run, there is a limit.   |
+| RESULT_NAME_PREFIX | result_{nr}                                 | String               | Result name. {nr} will be replaced by an incremental number. |
+| EXCLUDED_PATHS     | []                                          | List of Strings      | Separated by commas. Files/Paths to exclude during a run.    |
+| LLM_FILE           | models/ggml-model-gpt4all-falcon-q4_0.bin   | String               | If running with LLM, this has to be set linking to a model.  |
+| RUN_WITH_LLM       | false                                       | String               | Whether to use LLM during the run or not.                    |
+| PATH_TO_CODE       | src/test/resources/                         | String               | Required attribute. Where the code is located.               |
 
 #### LOGGING_LEVEL
 The different options are the following:

--- a/README.md
+++ b/README.md
@@ -68,18 +68,19 @@ The results will be shown in the `/results/` folder. By default, the result nami
 You can edit some configuration in `config.properties`.
 
 ### Properties
-| Property           | Default values if not set (if not required) | Type                 | Description                                                  |
-|--------------------|---------------------------------------------|----------------------|--------------------------------------------------------------|
-| LOGGING_LEVEL      | DEBUG                                       | String               | What level to show logs in.                                  |
-| TEMP_FILE_ENABLED  | false                                       | Boolean (true/false) | Whether to use a temporary file.                             |
-| TEMP_FILE          | debugFile.txt                               | String               | Where the temporary file is located.                         |
-| PATH_TO_RESULTS    | results                                     | String               | Results directory.                                           |
-| RESULTS_FILE_LIMIT | 100                                         | Integer              | Since it's creating a new file each run, there is a limit.   |
-| RESULT_NAME_PREFIX | result_{nr}                                 | String               | Result name. {nr} will be replaced by an incremental number. |
-| EXCLUDED_PATHS     | []                                          | List of Strings      | Separated by commas. Files/Paths to exclude during a run.    |
-| LLM_FILE           | models/ggml-model-gpt4all-falcon-q4_0.bin   | String               | If running with LLM, this has to be set linking to a model.  |
-| RUN_WITH_LLM       | false                                       | String               | Whether to use LLM during the run or not.                    |
-| PATH_TO_CODE       | src/test/resources/                         | String               | Required attribute. Where the code is located.               |
+| Property             | Default values if not set (if not required) | Type         | Description                                                  |
+|----------------------|---------------------------------------------|--------------|--------------------------------------------------------------|
+| LOGGING_LEVEL        | DEBUG                                       | String       | What level to show logs in.                                  |
+| TEMP_FILE_ENABLED    | false                                       | Boolean      | Whether to use a temporary file.                             |
+| TEMP_FILE            | debugFile.txt                               | String       | Where the temporary file is located.                         |
+| PATH_TO_RESULTS      | results                                     | String       | Results directory.                                           |
+| RESULT_NAME_PREFIX   | result_{nr}                                 | String       | Result name. {nr} will be replaced by an incremental number. |
+| RESULTS_FILE_LIMIT   | 100                                         | Integer      | Since it's creating a new file each run, there is a limit.   |
+| EXCLUDED_PATHS       | []                                          | List<String> | Separated by commas. Files/Paths to exclude during a run.    |
+| RUN_WITH_LLM         | false                                       | String       | Whether to use LLM during the run or not.                    |
+| LLM_FILE             | models/ggml-model-gpt4all-falcon-q4_0.bin   | String       | If running with LLM, this has to be set linking to a model.  |
+| LLM_THREADS          | 4                                           | Integer      | How many threads the LLM will be using.                      |
+| PATH_TO_CODE         | src/test/resources/                         | String       | Required attribute. Where the code is located.               |
 
 #### LOGGING_LEVEL
 The different options are the following:

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ The results will be shown in the `/results/` folder. By default, the result nami
 You can edit some configuration in `config.properties`.
 
 ### Properties
+
 | Property             | Default values if not set (if not required) | Type         | Description                                                  |
 |----------------------|---------------------------------------------|--------------|--------------------------------------------------------------|
-| LOGGING_LEVEL        | DEBUG                                       | String       | What level to show logs in.                                  |
-| TEMP_FILE_ENABLED    | false                                       | Boolean      | Whether to use a temporary file.                             |
-| TEMP_FILE            | debugFile.txt                               | String       | Where the temporary file is located.                         |
+| LOGGING_LEVEL        | INFO                                        | String       | Which level to show the logging in.                          |
+| PATH_TO_CODE         | src/test/resources/                         | String       | Required attribute. Where the code is located.               |
 | PATH_TO_RESULTS      | results                                     | String       | Results directory.                                           |
 | RESULT_NAME_PREFIX   | result_{nr}                                 | String       | Result name. {nr} will be replaced by an incremental number. |
 | RESULTS_FILE_LIMIT   | 100                                         | Integer      | Since it's creating a new file each run, there is a limit.   |
@@ -80,7 +80,8 @@ You can edit some configuration in `config.properties`.
 | RUN_WITH_LLM         | false                                       | String       | Whether to use LLM during the run or not.                    |
 | LLM_FILE             | models/ggml-model-gpt4all-falcon-q4_0.bin   | String       | If running with LLM, this has to be set linking to a model.  |
 | LLM_THREADS          | 4                                           | Integer      | How many threads the LLM will be using.                      |
-| PATH_TO_CODE         | src/test/resources/                         | String       | Required attribute. Where the code is located.               |
+| TEMP_FILE_ENABLED    | false                                       | Boolean      | Whether to use a temporary file.                             |
+| TEMP_FILE            | debugFile.txt                               | String       | Where the temporary file is located.                         |
 
 #### LOGGING_LEVEL
 The different options are the following:

--- a/config.properties
+++ b/config.properties
@@ -1,21 +1,22 @@
-LOGGING_LEVEL=DEBUG
-  # This is related to TEMP_FILE below.
-TEMP_FILE_ENABLED=false
-  # If enabled, this file will be deleted and replaced every run instead of using the results files.
-TEMP_FILE=debugFile.txt
-  # Directory of where the result files are saved. By default, it ranges from 0 to 99.
+  # Valid values in order: OFF, ERROR, WARNING, INFO, DEBUG, TRACE.
+LOGGING_LEVEL=INFO
+  # Directory path to where the code will be scanned.
+PATH_TO_CODE=src/test/resources/
+  # Directory of where the result files are saved. By default, it ranges from 0 to 99, and can be changed in `RESULTS_FILE_LIMIT`.
 PATH_TO_RESULTS=results
   # Prefix for the result files.
 RESULT_NAME_PREFIX=result_{nr}
   # Max amount of results files to create before the limit is reached. Starting from 0. The default value is 100.
-RESULTS_FILE_LIMIT=300
+RESULTS_FILE_LIMIT=100
   # Set this property to a path that should be excluded. It's regex based, so writing [file1, file2] would exclude any file containing file1 and file2.
 EXCLUDED_PATHS=[]
   # Run with LLM - needs a model defined and will take more computing power and time to run.
-RUN_WITH_LLM=true
+RUN_WITH_LLM=false
   # The LLM located in project root.
 LLM_FILE=models/ggml-model-gpt4all-falcon-q4_0.bin
-  # How many different threads the LLM will be using when running.
+  # How many threads the LLM will be using when it's running.
 LLM_THREADS=4
-  # Directory path to where the code is to be scanned.
-PATH_TO_CODE=src/test/resources/
+# This is related to the `TEMP_FILE` option. If the temp file option should be enabled or not.
+TEMP_FILE_ENABLED=false
+# If enabled, this file will be deleted and replaced every run instead of using the result files option.
+TEMP_FILE=debugFile.txt

--- a/config.properties
+++ b/config.properties
@@ -3,12 +3,14 @@ LOGGING_LEVEL=DEBUG
 TEMP_FILE_ENABLED=false
   # If enabled, this file will be deleted and replaced every run instead of using the results files.
 TEMP_FILE=debugFile.txt
-  # Directory of where the result files are saved. They range from 0 to 99.
+  # Directory of where the result files are saved. By default, it ranges from 0 to 99.
 PATH_TO_RESULTS=results
-  # Set this property to a path that should be excluded. It's regex based, so writing [file1, file2] would exclude any file containing file1 and file2.
-EXCLUDED_PATHS=[]
+  # Max amount of results files to create before the limit is reached. Starting from 0. The default value is 100.
+RESULTS_FILE_LIMIT=100
   # Prefix for the result files.
 RESULT_NAME_PREFIX=result_{nr}
+  # Set this property to a path that should be excluded. It's regex based, so writing [file1, file2] would exclude any file containing file1 and file2.
+EXCLUDED_PATHS=[]
   # The LLM located in project root.
 LLM_FILE=models/ggml-model-gpt4all-falcon-q4_0.bin
   # Run with LLM - needs a model defined and will take more computing power and time to run.

--- a/config.properties
+++ b/config.properties
@@ -5,15 +5,17 @@ TEMP_FILE_ENABLED=false
 TEMP_FILE=debugFile.txt
   # Directory of where the result files are saved. By default, it ranges from 0 to 99.
 PATH_TO_RESULTS=results
-  # Max amount of results files to create before the limit is reached. Starting from 0. The default value is 100.
-RESULTS_FILE_LIMIT=100
   # Prefix for the result files.
 RESULT_NAME_PREFIX=result_{nr}
+  # Max amount of results files to create before the limit is reached. Starting from 0. The default value is 100.
+RESULTS_FILE_LIMIT=300
   # Set this property to a path that should be excluded. It's regex based, so writing [file1, file2] would exclude any file containing file1 and file2.
 EXCLUDED_PATHS=[]
+  # Run with LLM - needs a model defined and will take more computing power and time to run.
+RUN_WITH_LLM=true
   # The LLM located in project root.
 LLM_FILE=models/ggml-model-gpt4all-falcon-q4_0.bin
-  # Run with LLM - needs a model defined and will take more computing power and time to run.
-RUN_WITH_LLM=false
+  # How many different threads the LLM will be using when running.
+LLM_THREADS=4
   # Directory path to where the code is to be scanned.
 PATH_TO_CODE=src/test/resources/

--- a/src/main/java/CodeCheck/CheckDirectory.java
+++ b/src/main/java/CodeCheck/CheckDirectory.java
@@ -83,8 +83,8 @@ public class CheckDirectory {
                         manyFunctions.commitFile(file.getName());
                         manyFunctions.commitLine(lineNumber);
 
-                        Log.trace("Full path: " + file.getAbsolutePath());
-                        Log.debug("Function: " +
+                        Log.debug("Full path: " + file.getAbsolutePath());
+                        Log.trace("Function: " +
                                 manyFunctions.commit.name + " in " +
                                 manyFunctions.commit.file + ":" +
                                 manyFunctions.commit.line + " with " +

--- a/src/main/java/CodeCheck/CheckDirectory.java
+++ b/src/main/java/CodeCheck/CheckDirectory.java
@@ -83,7 +83,7 @@ public class CheckDirectory {
                         manyFunctions.commitFile(file.getName());
                         manyFunctions.commitLine(lineNumber);
 
-                        Log.debug("Full path: " + file.getAbsolutePath());
+                        Log.debug("Accessing file at the path: " + file.getAbsolutePath());
                         Log.trace("Function: " +
                                 manyFunctions.commit.name + " in " +
                                 manyFunctions.commit.file + ":" +

--- a/src/main/java/CodeCheck/CheckDirectory.java
+++ b/src/main/java/CodeCheck/CheckDirectory.java
@@ -3,6 +3,7 @@ package CodeCheck;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
 import java.util.function.Predicate;
@@ -16,6 +17,7 @@ public class CheckDirectory {
     private final List<Pattern> EXCLUDED_PATHS = ConfigInterface
             .conf
             .getList("EXCLUDED_PATHS")
+            .orElse(Collections.emptyList())
             .stream()
             .filter(Predicate.not(String::isEmpty))
             .map(path -> "((?i)" + path.trim() + "(?-i))")
@@ -26,7 +28,7 @@ public class CheckDirectory {
         llm.initModel();
     }
 
-    public void stopModel() throws Exception {
+    public void stopModel() {
         llm.cleanModel();
     }
 

--- a/src/main/java/CodeCheck/CodeCheck.java
+++ b/src/main/java/CodeCheck/CodeCheck.java
@@ -4,9 +4,11 @@ import java.io.File;
 import java.util.List;
 
 public interface CodeCheck {
+
     static void execute() throws Exception {
         ConfigInterface.conf.loadConfig();
-        String PATH_TO_CODE = Util.checkIfHomePath(ConfigInterface.conf.getString("PATH_TO_CODE"));
+
+        String PATH_TO_CODE = Util.checkIfHomePath(ConfigInterface.conf.getProperty("PATH_TO_CODE"));
         File baseCodeDir = new File(PATH_TO_CODE);
 
         CheckDirectory checkDirectory = new CheckDirectory();

--- a/src/main/java/CodeCheck/ConfigInterface.java
+++ b/src/main/java/CodeCheck/ConfigInterface.java
@@ -82,7 +82,7 @@ public interface ConfigInterface {
 
         public Optional<Integer> getInteger(String key) {
             try {
-                return Optional.of(Integer.parseInt(key));
+                return Optional.of(Integer.parseInt(getProperty(key)));
             } catch (NumberFormatException | NullPointerException e) {
                 return Optional.empty();
             }
@@ -107,9 +107,14 @@ public interface ConfigInterface {
 
         public LoggingLevel getLogLvl() {
             String loggingLevel = getString("LOGGING_LEVEL")
-                    .orElse("DEBUG");
+                    .orElse("INFO");
 
-            return LoggingLevel.valueOf(loggingLevel);
+            try {
+                return LoggingLevel.valueOf(loggingLevel.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                Log.error(getLogLvl().name() + "::LoggingLevel got an error. %s.".formatted(e.getMessage()));
+                return LoggingLevel.INFO;
+            }
         }
 
         private int countLines(File file) throws IOException {

--- a/src/main/java/CodeCheck/ConfigInterface.java
+++ b/src/main/java/CodeCheck/ConfigInterface.java
@@ -58,7 +58,7 @@ public interface ConfigInterface {
             }
 
             try {
-                return appProps.get(key).toString();
+                return appProps.get(key).toString().strip();
             } catch (NullPointerException e) {
                 throw new NullPointerException(e.getMessage());
             }

--- a/src/main/java/CodeCheck/LLM.java
+++ b/src/main/java/CodeCheck/LLM.java
@@ -33,7 +33,8 @@ public class LLM {
             }
 
             model = new LLModel(modelPath);
-            model.setThreadCount(6);
+            model.setThreadCount(ConfigInterface.conf.getInteger("LLM_THREADS")
+                    .orElse(4));
 
             Log.debug("Thread Count: " + model.threadCount());
 

--- a/src/main/java/CodeCheck/LLM.java
+++ b/src/main/java/CodeCheck/LLM.java
@@ -64,12 +64,12 @@ public class LLM {
 
     public String getAnswer(String question) {
 
-        Log.debug("Question: " + question);
+        Log.trace("Question: " + question);
 
         return runIfConfig(() -> {
             String answer = model.chatCompletion(createMessage(question), config).choices.toString();
 
-            Log.debug("Answer: " + answer);
+            Log.trace("Answer: " + answer);
 
             return answer;
         }).orElse("LLM has not been configured.");

--- a/src/main/java/CodeCheck/LLM.java
+++ b/src/main/java/CodeCheck/LLM.java
@@ -21,8 +21,8 @@ public class LLM {
         startTime = System.currentTimeMillis();
 
         runIfConfig(() -> {
-            Path modelPath = Path.of(Util.checkIfHomePath(
-                    ConfigInterface.conf.getString("LLM_FILE")));
+            Path modelPath = ConfigInterface.conf.getBoolean("RUN_WITH_LLM")
+                            .orElse(false) ? Path.of(Util.checkIfHomePath(ConfigInterface.conf.getProperty("LLM_FILE"))) : null;
 
             if (Files.isDirectory(modelPath)) {
                 Log.error("LLM_FILE not configured correctly - it is a directory, but was expecting a model file. Please change it into a correct model filepath.");
@@ -51,15 +51,13 @@ public class LLM {
             try {
                 model.close();
             } catch (Exception e) {
-                String errorMessage = "LLM is not closing...";
-                Log.error(errorMessage);
-                throw new RuntimeException(errorMessage, e);
+                throw new RuntimeException("LLM is not closing...", e);
             }
             return true;
         });
 
-        int[] formattedTime = Util.getFormattedDurationTime(startTime);
-        Log.log(String.format("LLM run completed in %02d hours, %02d minutes, %02d seconds and %02d milliseconds.",
+        int[] formattedTime = Util.getPreparedDurationTime(startTime);
+        Log.log(String.format("Run completed in %02d hours, %02d minutes, %02d seconds and %02d milliseconds.",
                 formattedTime[0], formattedTime[1], formattedTime[2], formattedTime[3]));
     }
 
@@ -81,7 +79,8 @@ public class LLM {
     }
 
     private <T> Optional<T> runIfConfig(Supplier<T> supplier) {
-        if (ConfigInterface.conf.getBoolean("RUN_WITH_LLM")) {
+        if (ConfigInterface.conf.getBoolean("RUN_WITH_LLM")
+                .orElse(false)) {
             return Optional.of(supplier.get());
         }
         return Optional.empty();

--- a/src/main/java/CodeCheck/Main.java
+++ b/src/main/java/CodeCheck/Main.java
@@ -1,12 +1,18 @@
 package CodeCheck;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class Main {
+
     public static void main(String[] args) throws Exception {
-        Log.log("Starting up...");
+        long startTime = System.currentTimeMillis();
+        Log.log("Starting up at: %s.".formatted(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))));
         Log.log("Running on %s.".formatted(System.getProperty("os.name")));
 
         CodeCheck.execute();
 
-        Log.log("Shutting down...");
+        Log.log("Shutting down at: %s.".formatted(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))));
+        Log.log("Total duration: %s".formatted(Util.getFormattedDurationTime(startTime)));
     }
 }

--- a/src/main/java/CodeCheck/OneFunction.java
+++ b/src/main/java/CodeCheck/OneFunction.java
@@ -60,8 +60,8 @@ public class OneFunction {
 
     public String llmComparison(OneFunction other, LLM llm) {
 
-        Log.debug(this.content.toString());
-        Log.debug(other.content.toString());
+        Log.trace("llmComparison->this:  " + this.content.toString());
+        Log.trace("llmComparison->this:  " + other.content.toString());
 
         String functionThis = getFunctionMsg(1) + this.content.toString(); // getFunctionMsg(1)
         String functionOther = getFunctionMsg(2) + other.content.toString(); // other.getFunctionMsg(2)

--- a/src/main/java/CodeCheck/OneFunction.java
+++ b/src/main/java/CodeCheck/OneFunction.java
@@ -2,14 +2,20 @@ package CodeCheck;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 public class OneFunction {
-    public String name;
-    public int nrParams;
-    public String file;
-    public int line;
-    public List<String> content = new ArrayList<>();
+    public String name, file;
+    public int nrParams, line;
+    public List<String> content;
+
+    private static final Pattern patternRemoveComments = Pattern.compile("(.*)(//.*)+");
+    private static final Pattern patternRemoveSpacesTabsNewLines = Pattern.compile("\\s");
+
+    public OneFunction() {
+        content = new ArrayList<>();
+    }
 
     public int equals(OneFunction obj) {
         if (obj.content.size() > 2 && obj.name.equals(name) && obj.removeExtraInformationAndGetString().equals(removeExtraInformationAndGetString()))
@@ -75,10 +81,11 @@ public class OneFunction {
 
     private List<String> removeExtraInformation() {
         return this.content.stream()
-                .map(s -> s.replaceAll("(.*)(//.*)+", "$1"))
-                .filter(s -> !s.matches("^\\s*//"))
-                .map(s -> s.replace(" ", ""))
-                .filter(s -> !s.startsWith("Log"))
-                .filter(s -> !s.isEmpty()).toList();
+                .map(String::strip)
+                .map(s -> patternRemoveComments.matcher(s).replaceAll("$1"))
+                .map(s -> patternRemoveSpacesTabsNewLines.matcher(s).replaceAll(""))
+                .filter(s -> !s.startsWith(Log.class.getSimpleName()))
+                .filter(Predicate.not(String::isEmpty))
+                .toList();
     }
 }

--- a/src/main/java/CodeCheck/OneFunction.java
+++ b/src/main/java/CodeCheck/OneFunction.java
@@ -13,36 +13,41 @@ public class OneFunction {
     private static final Pattern patternRemoveComments = Pattern.compile("(.*)(//.*)+");
     private static final Pattern patternRemoveSpacesTabsNewLines = Pattern.compile("\\s");
 
-    public OneFunction() {
+    protected OneFunction() {
         content = new ArrayList<>();
     }
 
     public int equals(OneFunction obj) {
         if (obj.content.size() > 2 && obj.name.equals(name) && obj.removeExtraInformationAndGetString().equals(removeExtraInformationAndGetString()))
             return 1;
-        if (obj.name.equals(name) && obj.content.size() > 4 && content.size() > 4) return 2;
-        if (obj.name.equals(name)) return 3;
+        if (obj.name.equals(name) && obj.content.size() > 4 && content.size() > 4)
+            return 2;
+        if (obj.name.equals(name))
+            return 3;
 
         return 10;
     }
 
     public Comparison compare(OneFunction other, LLM llm) {
-        switch (equals(other)) {
-            case 1: return new Comparison(true, "Functions are identical").setFunctions(this, other);
-            case 2: return similar(other, llm);
-            case 3: return new Comparison(false, false, "Empty or closetherby");
-            default:
-                return new Comparison();
-        }
+        return switch (equals(other)) {
+            case 1 -> new Comparison(true, "Functions are identical.").setFunctions(this, other);
+            case 2 -> similar(other, llm);
+            case 3 -> new Comparison(false, false, "Empty or closetherby.");
+            default -> new Comparison();
+        };
     }
 
     private Comparison similar(OneFunction obj, LLM llm) {
         List<String> thisCont = removeExtraInformation();
         List<String> objCont = obj.removeExtraInformation();
 
-        int matchingLines = objCont.stream().filter(objLine -> thisCont.contains(objLine)).toList().size();
+        int matchingLines = objCont
+                .stream()
+                .filter(thisCont::contains)
+                .toList()
+                .size();
 
-        if ((matchingLines + 0.0)/objCont.size() > 0.5 || matchingLines > 10)
+        if ((matchingLines + 0.0) / objCont.size() > 0.5 || matchingLines > 10)
             return new Comparison(false, true, "Matching lines " + matchingLines + " out of " + objCont.size()).setFunctions(this, obj);
         else
             return new Comparison(false, true, llmComparison(obj, llm)).setFunctions(this, obj);

--- a/src/main/java/CodeCheck/OneFunction.java
+++ b/src/main/java/CodeCheck/OneFunction.java
@@ -61,7 +61,7 @@ public class OneFunction {
     public String llmComparison(OneFunction other, LLM llm) {
 
         Log.trace("llmComparison->this:  " + this.content.toString());
-        Log.trace("llmComparison->this:  " + other.content.toString());
+        Log.trace("llmComparison->other:  " + other.content.toString());
 
         String functionThis = getFunctionMsg(1) + this.content.toString(); // getFunctionMsg(1)
         String functionOther = getFunctionMsg(2) + other.content.toString(); // other.getFunctionMsg(2)

--- a/src/main/java/CodeCheck/Util.java
+++ b/src/main/java/CodeCheck/Util.java
@@ -17,7 +17,7 @@ public interface Util {
                 if (isFirstTry)
                     Log.log("The file %s already exist, trying to create the next id... ", file.getPath());
                 else
-                    Log.log("%s ... ", file.getPath());
+                    Log.trace("Trying %s... ".formatted(file.getName()));
 
                 return null;
             }

--- a/src/main/java/CodeCheck/Util.java
+++ b/src/main/java/CodeCheck/Util.java
@@ -49,13 +49,27 @@ public interface Util {
      * @param startTime Input the start time.
      * @return An integer array of time the duration in HH:MM:SS:MS. 0 = h, 1 = m, 2 = s, 3 = ms
      */
-    static int[] getPreparedDurationTime(long startTime) {
-        long millis = (System.currentTimeMillis() - startTime);
+    static int[] getPreparedTime(long startTime, long endTime) {
+        long millis = (endTime - startTime);
         int seconds = (int) millis / 1000;
         int minutes = (seconds % 3600) / 60;
         int hours = seconds / 3600;
 
         return new int[] {hours, minutes, seconds % 60, (int) millis % 1000};
+    }
+
+    static int[] getPreparedDurationTime(long startTime) {
+        return getPreparedTime(startTime, System.currentTimeMillis());
+    }
+
+    static String getFormattedDurationTime(long startTime, long endTime) {
+        int[] t = getPreparedTime(startTime, endTime);
+        return "%02d hours, %02d minutes, %02d seconds and %02d milliseconds"
+                .formatted(t[0], t[1], t[2], t[3]);
+    }
+
+    static String getFormattedDurationTime(long startTime) {
+        return getFormattedDurationTime(startTime, System.currentTimeMillis());
     }
 
     static String checkIfHomePath(String path) {

--- a/src/main/java/CodeCheck/Util.java
+++ b/src/main/java/CodeCheck/Util.java
@@ -49,13 +49,13 @@ public interface Util {
      * @param startTime Input the start time.
      * @return An integer array of time the duration in HH:MM:SS:MS. 0 = h, 1 = m, 2 = s, 3 = ms
      */
-    static int[] getFormattedDurationTime(long startTime) {
+    static int[] getPreparedDurationTime(long startTime) {
         long millis = (System.currentTimeMillis() - startTime);
         int seconds = (int) millis / 1000;
         int minutes = (seconds % 3600) / 60;
         int hours = seconds / 3600;
 
-        return new int[]{hours, minutes, seconds % 60, (int) millis % 1000};
+        return new int[] {hours, minutes, seconds % 60, (int) millis % 1000};
     }
 
     static String checkIfHomePath(String path) {

--- a/src/main/java/CodeCheck/WriteObjectToFile.java
+++ b/src/main/java/CodeCheck/WriteObjectToFile.java
@@ -48,8 +48,12 @@ public class WriteObjectToFile {
             }
         }
 
+        int resultsLimit = RESULTS_FILE_LIMIT <= 0 ? 100 : RESULTS_FILE_LIMIT;
+        if (RESULTS_FILE_LIMIT <= 0)
+            Log.warning("The results file limit '%d' is incorrect - setting the limit to %d.".formatted(RESULTS_FILE_LIMIT, resultsLimit));
+
         // Look for the next file to write towards.
-        for (int i = 0; i < RESULTS_FILE_LIMIT; i++) {
+        for (int i = 0; i < resultsLimit; i++) {
 
             String prefix = RESULT_NAME_PREFIX.isEmpty() // Check if it's empty - in case it would be `""`.
                     ? "result_%d.txt".formatted(i) // Nothing is set, so use the default value.
@@ -61,8 +65,8 @@ public class WriteObjectToFile {
 
             if (createFile(fileName, i == 0)) break;
 
-            if (i >= RESULTS_FILE_LIMIT - 1) {
-                throw new Exception("Warning! The maximum amount of result of %d files has been reached! Cannot continue execution. Please increase the maximum limit, use another filename or path, or delete existing result files.".formatted(RESULTS_FILE_LIMIT));
+            if (i >= resultsLimit - 1) {
+                throw new Exception("Warning! The maximum amount of result of %d files has been reached! Cannot continue execution. Please increase the maximum limit, use another filename or path, or delete existing result files.".formatted(resultsLimit));
             }
         }
     }
@@ -73,6 +77,10 @@ public class WriteObjectToFile {
     }
 
     public void write(String obj) {
-        Util.write(PATH_TO_RESULTS + File.separator + file.getName(), obj);
+        try {
+            Util.write(PATH_TO_RESULTS + File.separator + file.getName(), obj);
+        } catch (NullPointerException e) {
+            throw new NullPointerException(e.getMessage());
+        }
     }
 }

--- a/src/main/java/CodeCheck/WriteObjectToFile.java
+++ b/src/main/java/CodeCheck/WriteObjectToFile.java
@@ -2,13 +2,20 @@ package CodeCheck;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 public class WriteObjectToFile {
 
-    private final String TEMP_FILE =  Util.checkIfHomePath(ConfigInterface.conf.getString("TEMP_FILE"));
-    private final boolean TEMP_FILE_ENABLED = ConfigInterface.conf.getBoolean("TEMP_FILE_ENABLED");
-    private final String RESULT_NAME_PREFIX = ConfigInterface.conf.getString("RESULT_NAME_PREFIX");
-    private final String PATH_TO_RESULTS = Util.checkIfHomePath(ConfigInterface.conf.getString("PATH_TO_RESULTS"));
+    private final String TEMP_FILE =  Util.checkIfHomePath(ConfigInterface.conf.getString("TEMP_FILE")
+            .orElse("debugFile.txt"));
+    private final boolean TEMP_FILE_ENABLED = ConfigInterface.conf.getBoolean("TEMP_FILE_ENABLED")
+            .orElse(false);
+    private final String PATH_TO_RESULTS = Util.checkIfHomePath(ConfigInterface.conf.getString("PATH_TO_RESULTS")
+            .orElse("results"));
+    private final String RESULT_NAME_PREFIX = ConfigInterface.conf.getString("RESULT_NAME_PREFIX")
+            .orElse("result_{nr}");
+    private final int RESULTS_FILE_LIMIT = ConfigInterface.conf.getInteger("RESULTS_FILE_LIMIT")
+            .orElse(100);
     private File file;
 
     public WriteObjectToFile() throws Exception {
@@ -18,33 +25,31 @@ public class WriteObjectToFile {
             File tempFile = new File(PATH_TO_RESULTS + File.separator + TEMP_FILE);
 
             if (tempFile.isFile()) {
-                tempFile.delete();
-                Log.log("Debug mode enabled - deleting the temporary file %s before continuing... ".formatted(tempFile.getPath()));
+                try {
+                    tempFile.delete();
+                    Log.log("Debug mode enabled - deleting the temporary results file '%s' before continuing... ".formatted(tempFile.getPath()));
+                } catch (Exception e) {
+                    throw new IOException("Debug mode enabled - could not delete the temporary results file '%s'!".formatted(tempFile.getPath()), e.getCause());
+                }
             } else if (tempFile.isDirectory()) {
-                String errorMessage = "Debug mode enabled - The temporary file '%s' is a directory. Cannot continue!";
-                Log.error(errorMessage);
-                throw new FileNotFoundException(errorMessage);
+                throw new FileNotFoundException("Debug mode enabled - The temporary file '%s' is a directory. Cannot continue!".formatted(tempFile.getPath()));
             }
         }
 
         // Create results directory if it doesn't exist.
-        File file = new File(PATH_TO_RESULTS);
-        if (!file.isDirectory()) {
-            if (file.mkdirs()) {
-                Log.log("Created directory %s...".formatted(file.getAbsolutePath()));
+        File resultsDir = new File(PATH_TO_RESULTS);
+        if (!resultsDir.isDirectory()) {
+            if (resultsDir.mkdirs()) {
+                Log.log("Created directory %s...".formatted(resultsDir.getAbsolutePath()));
             } else {
-                String errorMessage = "Could not create directory %s.".formatted(file.getAbsolutePath());
-                Log.error(errorMessage);
-                throw new Exception(errorMessage);
+                throw new Exception("Could not create directory %s.".formatted(resultsDir.getAbsolutePath()));
             }
         } else {
-            Log.log("The results directory `%s` already exists, no need to create it.".formatted(file.getName()));
+            Log.log("The results directory `%s` already exists, no need to create it.".formatted(resultsDir.getName()));
         }
 
         // Look for the next file to write towards.
-        final int maxResultsFiles = 100;
-
-        for (int i = 0; i < maxResultsFiles; i++) {
+        for (int i = 0; i < RESULTS_FILE_LIMIT; i++) {
 
             String prefix = RESULT_NAME_PREFIX.isEmpty()
                     ? "result_" + i // If nothing is set, use the default value.
@@ -56,10 +61,8 @@ public class WriteObjectToFile {
 
             if (createFile(fileName, i == 0)) break;
 
-            if (i == maxResultsFiles - 1) {
-                String errorMessage = "Warning! The maximum amount of result of %d files has been reached! Cannot continue execution.".formatted(maxResultsFiles);
-                Log.error(errorMessage);
-                throw new Exception(errorMessage);
+            if (i == RESULTS_FILE_LIMIT - 1) {
+                throw new Exception("Warning! The maximum amount of result of %d files has been reached! Cannot continue execution. Please increase the maximum limit, use another filename or path, or delete existing result files.".formatted(RESULTS_FILE_LIMIT));
             }
         }
     }

--- a/src/main/java/CodeCheck/WriteObjectToFile.java
+++ b/src/main/java/CodeCheck/WriteObjectToFile.java
@@ -6,15 +6,15 @@ import java.io.IOException;
 
 public class WriteObjectToFile {
 
-    private final String TEMP_FILE =  Util.checkIfHomePath(ConfigInterface.conf.getString("TEMP_FILE")
-            .orElse("debugFile.txt"));
-    private final boolean TEMP_FILE_ENABLED = ConfigInterface.conf.getBoolean("TEMP_FILE_ENABLED")
+    private static final boolean TEMP_FILE_ENABLED = ConfigInterface.conf.getBoolean("TEMP_FILE_ENABLED")
             .orElse(false);
-    private final String PATH_TO_RESULTS = Util.checkIfHomePath(ConfigInterface.conf.getString("PATH_TO_RESULTS")
+    private static final String TEMP_FILE = Util.checkIfHomePath(ConfigInterface.conf.getString("TEMP_FILE")
+            .orElse("debugFile.txt"));
+    private static final String PATH_TO_RESULTS = Util.checkIfHomePath(ConfigInterface.conf.getString("PATH_TO_RESULTS")
             .orElse("results"));
-    private final String RESULT_NAME_PREFIX = ConfigInterface.conf.getString("RESULT_NAME_PREFIX")
+    private static final String RESULT_NAME_PREFIX = ConfigInterface.conf.getString("RESULT_NAME_PREFIX")
             .orElse("result_{nr}");
-    private final int RESULTS_FILE_LIMIT = ConfigInterface.conf.getInteger("RESULTS_FILE_LIMIT")
+    private static final int RESULTS_FILE_LIMIT = ConfigInterface.conf.getInteger("RESULTS_FILE_LIMIT")
             .orElse(100);
     private File file;
 
@@ -38,30 +38,30 @@ public class WriteObjectToFile {
 
         // Create results directory if it doesn't exist.
         File resultsDir = new File(PATH_TO_RESULTS);
-        if (!resultsDir.isDirectory()) {
+        if (resultsDir.isDirectory()) {
+            Log.log("The results directory `%s` already exists, no need to create it.".formatted(resultsDir.getName()));
+        } else {
             if (resultsDir.mkdirs()) {
                 Log.log("Created directory %s...".formatted(resultsDir.getAbsolutePath()));
             } else {
                 throw new Exception("Could not create directory %s.".formatted(resultsDir.getAbsolutePath()));
             }
-        } else {
-            Log.log("The results directory `%s` already exists, no need to create it.".formatted(resultsDir.getName()));
         }
 
         // Look for the next file to write towards.
         for (int i = 0; i < RESULTS_FILE_LIMIT; i++) {
 
-            String prefix = RESULT_NAME_PREFIX.isEmpty()
-                    ? "result_" + i // If nothing is set, use the default value.
-                    : RESULT_NAME_PREFIX.contains("{nr}") // If {nr} exist, replace all with the counter value.
-                    ? RESULT_NAME_PREFIX.replaceAll("\\{nr}", String.valueOf(i))
-                    : RESULT_NAME_PREFIX + i; // If {nr} doesn't exist, add the counter to the end of prefix.
+            String prefix = RESULT_NAME_PREFIX.isEmpty() // Check if it's empty - in case it would be `""`.
+                    ? "result_%d.txt".formatted(i) // Nothing is set, so use the default value.
+                    : RESULT_NAME_PREFIX.contains("{nr}") // If `{nr}` exists, then replace `{nr}`.
+                    ? RESULT_NAME_PREFIX.replace("{nr}", String.valueOf(i)) // Replace {nr} with the current counter value.
+                    : RESULT_NAME_PREFIX + i; // If `{nr}` doesn't exist, add the incremental counter to the end of the prefix value.
 
             String fileName = TEMP_FILE_ENABLED ? TEMP_FILE : prefix + ".txt";
 
             if (createFile(fileName, i == 0)) break;
 
-            if (i == RESULTS_FILE_LIMIT - 1) {
+            if (i >= RESULTS_FILE_LIMIT - 1) {
                 throw new Exception("Warning! The maximum amount of result of %d files has been reached! Cannot continue execution. Please increase the maximum limit, use another filename or path, or delete existing result files.".formatted(RESULTS_FILE_LIMIT));
             }
         }

--- a/src/test/java/CodeCheckTest.java
+++ b/src/test/java/CodeCheckTest.java
@@ -127,7 +127,7 @@ public class CodeCheckTest {
             while (myReader.hasNextLine()) {
                 String data = myReader.nextLine();
                 content.append("\n").append(data);
-                Log.debug(data);
+                Log.trace("readResult->data: " + data);
             }
 
             myReader.close();

--- a/src/test/java/CodeCheckTest.java
+++ b/src/test/java/CodeCheckTest.java
@@ -1,6 +1,8 @@
 import CodeCheck.CodeCheck;
 import CodeCheck.Log;
 import CodeCheck.Util;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -10,34 +12,60 @@ import java.util.List;
 import java.util.Scanner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CodeCheckTest {
 
-    private final String userDirectory = System.getProperty("user.dir");
-    private final String testConfPath = userDirectory + File.separator + "test-config.properties";
+    private static final String userDirectory = System.getProperty("user.dir");
+    private static final String testConfPath = userDirectory + File.separator + "test-config.properties";
     private final String resultFolder = "test-results";
     private final String resultNamePrefix = "test-result_{nr}";
     private final String resultFileName = "test-result_0.txt";
 
+
+    @BeforeEach
+    public void BeforeEach() {
+        delete(userDirectory + File.separator + resultFolder);
+    }
+
+    @AfterAll
+    public static void AfterAll() {
+        emptyTestConf();
+    }
+
     @Test
     public void executeTest() throws Exception {
-        delete(userDirectory + File.separator + resultFolder);
-
         writeConf();
         CodeCheck.execute();
 
         assertEquals(2, readResult().split("\n").length - 1);
+    }
 
-        emptyTestConf();
+    @Test
+    public void executeMinimalTest() throws Exception {
+        writeMinimalConf();
+        CodeCheck.execute();
+
+        assertEquals(2, readResult().split("\n").length - 1);
+    }
+
+    @Test
+    public void executeEmptyTest() {
+        writeEmptyConf();
+
+        Exception e = assertThrows(NullPointerException.class, CodeCheck::execute);
+
+        assertEquals(e.getMessage(),
+                "Cannot invoke \"Object.toString()\" because the return value of \"java.util.Properties.get(Object)\" is null");
     }
 
     private void delete(String path) {
         File dir = new File(path);
-        if (dir.isDirectory()) {
+        if (dir.isDirectory() && dir.getName().contains("test")) {
             Arrays.stream(dir.listFiles()).forEach(File::delete);
             dir.delete();
         } else {
-            Log.warning("Could not delete '%s' directory as it doesn't exist.".formatted(resultFolder));
+            Log.log("Could not delete '%s' directory as it doesn't exist.".formatted(resultFolder));
         }
     }
 
@@ -56,7 +84,27 @@ public class CodeCheckTest {
         conf.forEach(line -> Util.write(testConfPath, line));
     }
 
-    private void emptyTestConf() {
+    private void writeMinimalConf() {
+        List<String> conf = List.of(
+                "PATH_TO_RESULTS=" + resultFolder, // Is optional - used for testing.
+                "RESULT_NAME_PREFIX=" + resultNamePrefix, // Is optional - used for testing.
+                "PATH_TO_CODE=src/test/resources/"); // Is required.
+
+        Util.write(testConfPath, "# properties used under testing - this file will be overwritten during testing", false);
+        conf.forEach(line -> Util.write(testConfPath, line));
+    }
+
+    private void writeEmptyConf() {
+        List<String> conf = List.of(
+                "PATH_TO_RESULTS=" + resultFolder, // Is optional - used for testing.
+                "RESULT_NAME_PREFIX=" + resultNamePrefix // Is optional - used for testing.
+        );
+
+        Util.write(testConfPath, "# properties used under testing - this file will be overwritten during testing", false);
+        conf.forEach(line -> Util.write(testConfPath, line));
+    }
+
+    private static void emptyTestConf() {
         Util.write(testConfPath, "# empty -- properties used under testing -- this file will be overwritten during testing", false);
     }
 
@@ -80,9 +128,7 @@ public class CodeCheckTest {
             myReader.close();
 
         } catch (FileNotFoundException e) {
-            String errorMessage = "Testing result file not found. %s".formatted(e.getMessage());
-            Log.error(errorMessage);
-            throw new FileNotFoundException(errorMessage + "\n" + Arrays.toString(e.getStackTrace()));
+            throw new FileNotFoundException("Testing result file not found. %s\n%s".formatted(e.getMessage(), Arrays.toString(e.getStackTrace())));
         }
 
         return content.toString();

--- a/src/test/java/CodeCheckTest.java
+++ b/src/test/java/CodeCheckTest.java
@@ -18,6 +18,7 @@ public class CodeCheckTest {
 
     private static final String userDirectory = System.getProperty("user.dir");
     private static final String testConfPath = userDirectory + File.separator + "test-config.properties";
+
     private final String resultFolder = "test-results";
     private final String resultNamePrefix = "test-result_{nr}";
     private final String resultFileName = "test-result_0.txt";
@@ -71,14 +72,18 @@ public class CodeCheckTest {
 
     private void writeConf() {
         List<String> conf = List.of(
-                "LOGGING_LEVEL=DEBUG",
-                "TEMP_FILE_ENABLED=false",
-                "TEMP_FILE=debugFile.txt",
+                "LOGGING_LEVEL=INFO",
+                "PATH_TO_CODE=src/test/resources/",
                 "PATH_TO_RESULTS=" + resultFolder,
                 "RESULT_NAME_PREFIX=" + resultNamePrefix,
+                "RESULTS_FILE_LIMIT=100",
+                "EXCLUDED_PATHS=[]",
+                "LLM_FILE=\"\"",
                 "RUN_WITH_LLM=false",
-                "PATH_TO_CODE=src/test/resources/",
-                "EXCLUDED_PATHS=[]");
+                "LLM_THREADS=4",
+                "TEMP_FILE_ENABLED=false",
+                "TEMP_FILE=debugFile.txt"
+        );
 
         Util.write(testConfPath, "# properties used under testing - this file will be overwritten during testing", false);
         conf.forEach(line -> Util.write(testConfPath, line));


### PR DESCRIPTION
Summary:
- [1922faf0334ea80427707b8266c75fdd962d5252] Improved regex speed in `OneFunction.java` by using a compiled pattern instead.
- [4852189be5def71d5f4806e13829fc1ef67ff280] Added a new value `RESULTS_FILE_LIMIT` for configuration.
- [4852189be5def71d5f4806e13829fc1ef67ff280] Added optional values when reading from the config for default values instead of crashes if a key is incorrect.
- [4852189be5def71d5f4806e13829fc1ef67ff280] Added tests for config.
- [4852189be5def71d5f4806e13829fc1ef67ff280] Added a table of default config values to `README.md`.
- [4852189be5def71d5f4806e13829fc1ef67ff280] `getString(...)` to get config value is renamed to `getProperty(...)`.
- [4852189be5def71d5f4806e13829fc1ef67ff280] Some refactoring and other minor changes.
- [de6d496c1f9de4b0bc67bbeee3366accc2d6d929] Added `LLM_THREADS` to configuration.
- [13bda16690bc2adc2e88c5860b9f2da180a30980] Changes, refactoring and a fix for `getInteger(...)`.
- [139a403f4154cefa50fe50ab87c302b6366b1fd5] Changed some logging from debug to trace. Added startup, shutdown and duration time.
- [2b940161ec8c76f74e8b6b8a1d76d12f189abcef] Fixed: #27
- [f0b836d6faba20d943eca7dc63eb5163e38b3821] Fixed: #23